### PR TITLE
Rejuvenate log levels

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
@@ -131,7 +131,7 @@ public class Ctags implements Resettable {
         IOUtils.close(ctagsIn);
         if (ctags != null) {
             closing = true;
-            LOGGER.log(Level.FINE, "Destroying ctags command");
+            LOGGER.log(Level.FINEST, "Destroying ctags command");
             ctags.destroyForcibly();
         }
     }
@@ -399,7 +399,7 @@ public class Ctags implements Resettable {
                 int exitValue = ctags.exitValue();
                 // If it is possible to retrieve exit value without exception
                 // this means the ctags process is dead.
-                LOGGER.log(Level.WARNING, "Ctags process exited with exit value {0}",
+                LOGGER.log(Level.FINER, "Ctags process exited with exit value {0}",
                         exitValue);
                 // Throw the following to indicate non-I/O error for retry.
                 throw new InterruptedException("ctags process died");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationStack.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationStack.java
@@ -134,7 +134,7 @@ public class AuthorizationStack extends AuthorizationEntity {
         getCurrentSetup().putAll(parameters);
         getCurrentSetup().putAll(getSetup());
 
-        LOGGER.log(Level.INFO, "[{0}] Stack \"{1}\" is loading.",
+        LOGGER.log(Level.FINEST, "[{0}] Stack \"{1}\" is loading.",
                 new Object[]{getFlag().toString().toUpperCase(Locale.ROOT),
                 getName()});
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1715,7 +1715,7 @@ public final class RuntimeEnvironment {
      */
     public void applyConfig(Configuration config, boolean reindex, boolean interactive) {
         setConfiguration(config, interactive);
-        LOGGER.log(Level.INFO, "Configuration updated");
+        LOGGER.log(Level.FINEST, "Configuration updated");
 
         if (reindex) {
             // We are assuming that each update of configuration means reindex. If dedicated thread is introduced

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginClassLoader.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginClassLoader.java
@@ -98,7 +98,7 @@ public class PluginClassLoader extends ClassLoader {
                     try (InputStream is = jar.getInputStream(entry)) {
                         byte[] bytes = loadBytes(is);
                         Class c = defineClass(classname, bytes, 0, bytes.length);
-                        LOGGER.log(Level.FINE, "Class \"{0}\" found in file \"{1}\"",
+                        LOGGER.log(Level.FINEST, "Class \"{0}\" found in file \"{1}\"",
                                 new Object[]{
                                         classname,
                                         f.getAbsolutePath()

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
@@ -358,7 +358,7 @@ public abstract class PluginFramework<PluginType> {
             return;
         }
 
-        LOGGER.log(Level.INFO, "Plugins are being reloaded from {0}", pluginDirectory.getAbsolutePath());
+        LOGGER.log(Level.FINEST, "Plugins are being reloaded from {0}", pluginDirectory.getAbsolutePath());
 
         // trashing out the old instance of the loaded enables us
         // to reload the stack at runtime

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -417,7 +417,7 @@ class FileHistoryCache implements HistoryCache {
             return;
         }
 
-        LOGGER.log(Level.FINE,
+        LOGGER.log(Level.FINER,
             "Storing history for repository {0}",
             new Object[] {repository.getDirectoryName()});
 
@@ -490,7 +490,7 @@ class FileHistoryCache implements HistoryCache {
             fileHistoryCount++;
         }
 
-        LOGGER.log(Level.FINE, "Stored history for {0} files", fileHistoryCount);
+        LOGGER.log(Level.FINER, "Stored history for {0} files", fileHistoryCount);
 
         if (!handleRenamedFiles) {
             finishStore(repository, latestRev);
@@ -559,7 +559,7 @@ class FileHistoryCache implements HistoryCache {
         } catch (InterruptedException ex) {
             LOGGER.log(Level.SEVERE, "latch exception", ex);
         }
-        LOGGER.log(Level.FINE, "Stored history for {0} renamed files",
+        LOGGER.log(Level.FINER, "Stored history for {0} renamed files",
                 renamedFileHistoryCount.intValue());
         finishStore(repository, latestRev);
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/DefaultIndexChangedListener.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/DefaultIndexChangedListener.java
@@ -48,11 +48,11 @@ public class DefaultIndexChangedListener implements IndexChangedListener {
 
     @Override
     public void fileRemove(String path) {
-        LOGGER.log(Level.FINE, "Remove file:{0}", path);
+        LOGGER.log(Level.FINEST, "Remove file:{0}", path);
     }
     @Override
     public void fileUpdate(String path) {
-        LOGGER.log(Level.FINE, "Update: {0}", path);
+        LOGGER.log(Level.FINEST, "Update: {0}", path);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -608,7 +608,7 @@ public class IndexDatabase {
         try {
             Statistics elapsed = new Statistics();
             String projectDetail = this.project != null ? " for project " + project.getName() : "";
-            LOGGER.log(Level.INFO, "Optimizing the index{0}", projectDetail);
+            LOGGER.log(Level.FINE, "Optimizing the index{0}", projectDetail);
             Analyzer analyzer = new StandardAnalyzer();
             IndexWriterConfig conf = new IndexWriterConfig(analyzer);
             conf.setOpenMode(OpenMode.CREATE_OR_APPEND);
@@ -1331,7 +1331,7 @@ public class IndexDatabase {
             String exmsg = String.format(
                 "%d failures (%.1f%%) while parallel-indexing",
                 failureCount, pctFailed);
-            LOGGER.log(Level.WARNING, exmsg);
+            LOGGER.log(Level.FINER, exmsg);
         }
 
         /**
@@ -1702,7 +1702,7 @@ public class IndexDatabase {
             hasPendingCommit = true;
 
             int n = completer.complete();
-            LOGGER.log(Level.FINE, "completed {0} object(s)", n);
+            LOGGER.log(Level.FINEST, "completed {0} object(s)", n);
 
             // Just before commit(), reset the `hasPendingCommit' flag,
             // since after commit() is called, there is no need for

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexVersion.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexVersion.java
@@ -68,13 +68,13 @@ public class IndexVersion {
     public static void check(List<String> subFilesList) throws Exception {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         File indexRoot = new File(env.getDataRootPath(), IndexDatabase.INDEX_DIR);
-        LOGGER.log(Level.FINE, "Checking for Lucene index version mismatch in {0}",
+        LOGGER.log(Level.FINEST, "Checking for Lucene index version mismatch in {0}",
                 indexRoot);
 
         if (!subFilesList.isEmpty()) {
             // Assumes projects are enabled.
             for (String projectName : subFilesList) {
-                LOGGER.log(Level.FINER,
+                LOGGER.log(Level.FINEST,
                         "Checking Lucene index version in project {0}",
                         projectName);
                 checkDir(new File(indexRoot, projectName));
@@ -82,13 +82,13 @@ public class IndexVersion {
         } else {
             if (env.isProjectsEnabled()) {
                 for (String projectName : env.getProjects().keySet()) {
-                    LOGGER.log(Level.FINER,
+                    LOGGER.log(Level.FINEST,
                             "Checking Lucene index version in project {0}",
                             projectName);
                     checkDir(new File(indexRoot, projectName));
                 }
             } else {
-                LOGGER.log(Level.FINER, "Checking Lucene index version in {0}",
+                LOGGER.log(Level.FINEST, "Checking Lucene index version in {0}",
                         indexRoot);
                 checkDir(indexRoot);
             }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -872,7 +872,7 @@ public final class Indexer {
         if (filename != null) {
             LOGGER.log(Level.INFO, "Writing configuration to {0}", filename);
             env.writeConfiguration(new File(filename));
-            LOGGER.info("Done...");
+            LOGGER.finest("Done...");
         }
     }
 
@@ -976,14 +976,14 @@ public final class Indexer {
         if (createHistoryCache) {
             // Even if history is disabled globally, it can be enabled for some repositories.
             if (repositories != null && !repositories.isEmpty()) {
-                LOGGER.log(Level.INFO, "Generating history cache for repositories: " +
+                LOGGER.log(Level.FINER, "Generating history cache for repositories: " +
                         repositories.stream().collect(Collectors.joining(",")));
                 HistoryGuru.getInstance().createCache(repositories);
-                LOGGER.info("Done...");
+                LOGGER.finer("Done...");
             } else {
-                LOGGER.log(Level.INFO, "Generating history cache for all repositories ...");
+                LOGGER.log(Level.FINER, "Generating history cache for all repositories ...");
                 HistoryGuru.getInstance().createCache();
-                LOGGER.info("Done...");
+                LOGGER.finer("Done...");
             }
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
@@ -49,7 +49,7 @@ public class CtagsUtil {
             return false;
         }
 
-        LOGGER.log(Level.INFO, "Using ctags: {0}", output.trim());
+        LOGGER.log(Level.FINEST, "Using ctags: {0}", output.trim());
 
         return true;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
@@ -171,7 +171,7 @@ public class Executor {
             Map<String, String> env_map = processBuilder.environment();
             env_str = " with environment: " + env_map.toString();
         }
-        LOGGER.log(Level.FINE,
+        LOGGER.log(Level.FINEST,
                 "Executing command {0} in directory {1}{2}",
                 new Object[] {cmd_str, dir_str, env_str});
 
@@ -272,7 +272,7 @@ public class Executor {
                             msg.append(new String(stderr));
                     }
             }
-            LOGGER.log(Level.WARNING, msg.toString());
+            LOGGER.log(Level.FINEST, msg.toString());
         }
 
         return ret;

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
@@ -179,7 +179,7 @@ public class ProjectsController {
     public void deleteProjectData(@PathParam("project") String projectName) throws HistoryException {
 
         Project project = disableProject(projectName);
-        logger.log(Level.INFO, "deleting data for project {0}", projectName);
+        logger.log(Level.FINE, "deleting data for project {0}", projectName);
 
         List<RepositoryInfo> repos = env.getProjectRepositoriesMap().get(project);
 
@@ -204,7 +204,7 @@ public class ProjectsController {
     public void deleteHistoryCache(@PathParam("project") String projectName) throws HistoryException {
 
         Project project = disableProject(projectName);
-        logger.log(Level.INFO, "deleting history cache for project {0}", projectName);
+        logger.log(Level.FINER, "deleting history cache for project {0}", projectName);
 
         List<RepositoryInfo> repos = env.getProjectRepositoriesMap().get(project);
         if (repos == null || repos.isEmpty()) {

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
@@ -156,7 +156,7 @@ public class SuggesterServiceImpl implements SuggesterService {
     /** {@inheritDoc} */
     @Override
     public void refresh() {
-        logger.log(Level.FINE, "Refreshing suggester for new configuration {0}", env.getSuggesterConfig());
+        logger.log(Level.FINEST, "Refreshing suggester for new configuration {0}", env.getSuggesterConfig());
         lock.writeLock().lock();
         try {
             // close and init from scratch because many things may have changed in the configuration
@@ -351,7 +351,7 @@ public class SuggesterServiceImpl implements SuggesterService {
             return;
         }
 
-        logger.log(Level.INFO, "Scheduling suggester rebuild in {0}", timeToNextRebuild);
+        logger.log(Level.FINEST, "Scheduling suggester rebuild in {0}", timeToNextRebuild);
 
         future = instance.scheduler.schedule(instance.getRebuildAllProjectsRunnable(), timeToNextRebuild.toMillis(),
                 TimeUnit.MILLISECONDS);

--- a/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
@@ -110,7 +110,7 @@ public class LdapAttrPlugin extends AbstractLdapPlugin {
             throw new IllegalArgumentException(String.format("Unable to read the file \"%s\"", filePath), e);
         }
 
-        LOGGER.log(Level.FINE, "LdapAttrPlugin plugin loaded with attr={0}, whitelist={1}, instance={2}",
+        LOGGER.log(Level.FINER, "LdapAttrPlugin plugin loaded with attr={0}, whitelist={1}, instance={2}",
                 new Object[]{ldapAttr, filePath, ldapUserInstance});
     }
 
@@ -165,7 +165,7 @@ public class LdapAttrPlugin extends AbstractLdapPlugin {
             }
 
             if (records == null || records.isEmpty() || (attributeValues = records.get(ldapAttr)) == null) {
-                LOGGER.log(Level.WARNING, "empty records or attribute values {0} for user {1}",
+                LOGGER.log(Level.SEVERE, "empty records or attribute values {0} for user {1}",
                         new Object[]{ldapAttr, user});
                 return;
             }

--- a/plugins/src/main/java/opengrok/auth/plugin/LdapFilterPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapFilterPlugin.java
@@ -91,7 +91,7 @@ public class LdapFilterPlugin extends AbstractLdapPlugin {
             loadTransforms(transformsString);
         }
 
-        LOGGER.log(Level.FINE, "LdapFilter plugin loaded with filter={0}, instance={1}, transforms={2}",
+        LOGGER.log(Level.FINEST, "LdapFilter plugin loaded with filter={0}, instance={1}, transforms={2}",
                 new Object[]{ldapFilter, ldapUserInstance, transforms});
     }
 

--- a/plugins/src/main/java/opengrok/auth/plugin/LdapUserPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapUserPlugin.java
@@ -104,7 +104,7 @@ public class LdapUserPlugin extends AbstractLdapPlugin {
             instance = Integer.parseInt(instance_param);
         }
 
-        LOGGER.log(Level.FINE, "LdapUser plugin loaded with filter={0}, " +
+        LOGGER.log(Level.FINER, "LdapUser plugin loaded with filter={0}, " +
                         "attributes={1}, useDN={2}, instance={3}",
                 new Object[]{ldapFilter, attributes, useDN, instance});
     }
@@ -165,7 +165,7 @@ public class LdapUserPlugin extends AbstractLdapPlugin {
             AbstractLdapProvider.LdapSearchResult<Map<String, Set<String>>> res;
             if ((res = getLdapProvider().lookupLdapContent(dn, expandedFilter,
                     attributes.toArray(new String[0]))) == null) {
-                LOGGER.log(Level.WARNING, "failed to get LDAP attributes ''{2}'' for user {0} " +
+                LOGGER.log(Level.SEVERE, "failed to get LDAP attributes ''{2}'' for user {0} " +
                                 "with filter ''{1}'' from LDAP provider {3}",
                         new Object[]{user, expandedFilter, attributes, getLdapProvider()});
                 return;
@@ -180,14 +180,14 @@ public class LdapUserPlugin extends AbstractLdapPlugin {
         }
 
         if (records.isEmpty()) {
-            LOGGER.log(Level.WARNING, "LDAP records for user {0} are empty",
+            LOGGER.log(Level.SEVERE, "LDAP records for user {0} are empty",
                     user);
             return;
         }
 
         for (String attrName : attributes) {
             if (!records.containsKey(attrName) || records.get(attrName) == null || records.get(attrName).isEmpty()) {
-                LOGGER.log(Level.WARNING, "''{0}'' record for user {1} is not present or empty (LDAP provider: {2})",
+                LOGGER.log(Level.SEVERE, "''{0}'' record for user {1} is not present or empty (LDAP provider: {2})",
                         new Object[]{attrName, user, getLdapProvider()});
             }
         }

--- a/plugins/src/main/java/opengrok/auth/plugin/UserPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/UserPlugin.java
@@ -74,7 +74,7 @@ public class UserPlugin implements IAuthorizationPlugin {
                     DECODER_CLASS_PARAM, UserPlugin.class.getName()));
         }
 
-        LOGGER.log(Level.INFO, "loading decoder: {0}", decoder_name);
+        LOGGER.log(Level.FINEST, "loading decoder: {0}", decoder_name);
         try {
             decoder = getDecoder(decoder_name);
         } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException |

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -257,7 +257,7 @@ public final class Suggester implements Closeable {
         return () -> {
             try {
                 Instant start = Instant.now();
-                logger.log(Level.FINE, "Rebuilding {0}", data);
+                logger.log(Level.FINEST, "Rebuilding {0}", data);
                 data.rebuild();
 
                 Duration d = Duration.between(start, Instant.now());
@@ -278,7 +278,7 @@ public final class Suggester implements Closeable {
         }
 
         synchronized (lock) {
-            logger.log(Level.INFO, "Removing following suggesters: {0}", names);
+            logger.log(Level.FINE, "Removing following suggesters: {0}", names);
 
             for (String suggesterName : names) {
                 SuggesterProjectData collection = projectData.get(suggesterName);

--- a/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
+++ b/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
@@ -125,7 +125,7 @@ class SuggesterProjectData implements Closeable {
             } else if (!indexedFields.containsAll(fields)) {
                 Set<String> copy = new HashSet<>(fields);
                 copy.removeAll(indexedFields);
-                logger.log(Level.WARNING,
+                logger.log(Level.FINEST,
                         "Fields {0} will be ignored because they were not found in index directory {1}",
                         new Object[] {copy, indexDir});
 


### PR DESCRIPTION
Here's a reissue of 2754 with a new version of our tool. The tool made many fewer transformations. Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

- Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
- Never lower the logging level of logging statements within catch blocks.
- Never lower the logging level of logging statements within if statements.
- Never lower the logging level of logging statements containing certain (important) keywords.
- Never raise the logging level of logging statements without particular keywords in their messages.
- Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
- Maximum allowed transformation distance: 10.

The greatest number of commits from HEAD evaluated: 5000.
The head at the time of analysis was: 0f3b14dd3a50a75033e937b1bf8e6a90bb3ee154

OCA
---
I signed and emailed the OCA to Oracle. I am also providing a written acceptance of the OCA line:

I am signing on behalf of myself as an individual and no other person or entity, including my employer, has or will have rights with respect my contributions.
